### PR TITLE
Fix average calcuation when weight > 1

### DIFF
--- a/TDigest.Tests/Tests.cs
+++ b/TDigest.Tests/Tests.cs
@@ -48,6 +48,34 @@ namespace StatsLib.Tests {
         }
 
         [TestMethod]
+        public void TestWeightedDistribution()
+        {
+            Random r = new Random();
+
+            TDigest digest = new TDigest();
+            List<double> actual = new List<double>();
+            for (int i = 0; i < 10000; i++)
+            {
+                var v = r.NextDouble();
+                var w = r.Next(1, 10);
+                digest.Add(v, w);
+                for (int j = 0; j < w; j++)
+                {
+                    actual.Add(v);
+                }
+            }
+
+            actual.Sort();
+            Assert.AreEqual(actual.Count, digest.Count);
+
+            Assert.IsTrue(GetAvgError(actual, digest) < .01);
+            Assert.IsTrue(MaxIsEqual(actual, digest));
+            Assert.IsTrue(MinIsEqual(actual, digest));
+            var avgError = GetAvgPercentileError(actual, digest);
+            Assert.IsTrue(avgError < .0005);
+        }
+
+        [TestMethod]
         public void TestConstantValue() {
             Random r = new Random();
 

--- a/TDigest/TDigest.cs
+++ b/TDigest/TDigest.cs
@@ -154,7 +154,7 @@ namespace StatsLib {
                 Max = value;
             }
             else {
-                _newAvg = _oldAvg + (value - _oldAvg) / _count;
+                _newAvg = _oldAvg + (value - _oldAvg) * weight / _count;
                 _oldAvg = _newAvg;
                 Max = value > Max ? value : Max;
                 Min = value < Min ? value : Min;


### PR DESCRIPTION
When adding a value with weight > 1, the average is not updated correctly because it doesn't take weight into account.